### PR TITLE
Update byline capitalization

### DIFF
--- a/edits.css
+++ b/edits.css
@@ -139,7 +139,7 @@ div.newspack-post-subtitle {
 }
 
 /* Makes bylines and dates uppercase */
-span.byline {
+span.byline::first-letter {
     text-transform: capitalize;
 }
 
@@ -192,10 +192,6 @@ time.entry-date.published {
 .newspack-front-page #content a:hover, #content a:focus, #colophon a:hover, #colophon a:focus {
     color: #f5333f !important;
     text-decoration: underline;
-}
-
-.entry .byline {
-    text-transform: capitalize;
 }
 
 .entry .author {


### PR DESCRIPTION
This update changes the byline capitalization styles, so they only affect the first word ('By'), and aren't picked up by the 'and' that's added when there's more than one author.

It also removes a redundant style for the byline; the capitalization styles appear twice in the custom CSS.  

This has already been updated on the site. 